### PR TITLE
Add alt-text to RSS template

### DIFF
--- a/apps/comics/templates/comics/rss.xml
+++ b/apps/comics/templates/comics/rss.xml
@@ -36,7 +36,7 @@
           background-repeat: no-repeat;
         }
       </style>
-      <img src="{{ request.scheme }}://{{request.get_host}}{{ page.image.url }}"></img>
+      <img src="{{ request.scheme }}://{{request.get_host}}{{ page.image.url }}" title="{{ page.alt_text }}"></img>
       {{ page.transcript_html | safe }}
     ]]>
     </description>


### PR DESCRIPTION
Minor change to add the alt-text ("title") to the images in the RSS feed.