### PR TITLE
Refresh comments on tab activation, if necessary

### DIFF
--- a/apps/comics/templates/comics/js/reader.js
+++ b/apps/comics/templates/comics/js/reader.js
@@ -332,6 +332,20 @@ const COMICS = function () {
             }
         });
 
+        // Refresh discourse comments if loaded invisibly (no height)
+        if (target === 'comments-frame') {
+            let embedFrame = document.getElementById('discourse-embed-frame');
+            let embedHeight = -1;
+
+            if (embedFrame && embedFrame.height) {
+                embedHeight = parseInt(embedFrame.height, 10);
+            }
+
+            if (embedHeight <= 0) {
+                refreshDiscourseComments();
+            }
+        }
+
         // Set content styling
         document.querySelectorAll('.tab-content-area').forEach(function (element) {
             if (element.id === target) {


### PR DESCRIPTION
If the page is loaded while some tab other than the comments tab is active (comments load invisibly), the iframe will detect its height as `0` and fail to resize properly.

When activating the Comments tab, check the `.height` property of the embed, and force a refresh if it's `0` or hasn't been set.

Fixes #11