### PR TITLE
Refresh comments on tab activation with setTimeout

### DIFF
--- a/apps/comics/templates/comics/js/reader.js
+++ b/apps/comics/templates/comics/js/reader.js
@@ -156,7 +156,7 @@ const COMICS = function () {
         }
 
         // Try to refresh the comments
-        refreshDiscourseComments();
+        refreshDiscourseComments(true);
 
         // Try to show the popup
         window.setTimeout(attemptToShowPopup, 5000);
@@ -266,8 +266,21 @@ const COMICS = function () {
 
     document.onkeydown = keyboardNav;
 
-    function refreshDiscourseComments() {
+    function getCommentFrameHeight() {
+        const embedFrame = document.getElementById('discourse-embed-frame');
+        let embedHeight = -1;
+
+        if (embedFrame && embedFrame.height) {
+            embedHeight = parseInt(embedFrame.height, 10);
+        }
+        return embedHeight;
+    }
+
+    function refreshDiscourseComments(forced=true) {
         if (!DISCOURSE_URL) {
+            return;
+        }
+        if (!forced && getCommentFrameHeight() > 0) {
             return;
         }
         try {
@@ -332,20 +345,6 @@ const COMICS = function () {
             }
         });
 
-        // Refresh discourse comments if loaded invisibly (no height)
-        if (target === 'comments-frame') {
-            let embedFrame = document.getElementById('discourse-embed-frame');
-            let embedHeight = -1;
-
-            if (embedFrame && embedFrame.height) {
-                embedHeight = parseInt(embedFrame.height, 10);
-            }
-
-            if (embedHeight <= 0) {
-                refreshDiscourseComments();
-            }
-        }
-
         // Set content styling
         document.querySelectorAll('.tab-content-area').forEach(function (element) {
             if (element.id === target) {
@@ -354,6 +353,13 @@ const COMICS = function () {
                 element.style.display = "none";
             }
         });
+
+        // Queue a refresh check if comments loaded invisibly (no height)
+        if (target === 'comments-frame' && getCommentFrameHeight() <= 0) {
+            window.setTimeout(() => {
+                refreshDiscourseComments(false);
+            }, 0);
+        }
     }
 
     window.onpopstate = function (event) {


### PR DESCRIPTION
Here, give this version a spin and see if it helps.

I can't easily test this, since I don't have a working comics server to run it on. (I tested my previous PR by hacking it into a static copy of the site, but that only works locally which is why I didn't spot the Android issue in the first place.)

(**Edit:** Actually it's not just Android. I've seen it happen on swordscomic.com from Linux, now, too. It just loads too quickly, when testing **locally**, to trigger the bug.)

But hopefully this at least won't _break_ anything, and I'm optimistic it might improve the double-comments situation.

I added a `forced` argument to `refreshDiscourseComments()`, but made it default `true`. That way, if it's called anywhere else with no arguments, it'll still work the same as always. The arg is there specifically so that `activateTab()` can now queue an _UN_-forced refresh, which will do a second height check before it reloads the comments tab.

(Page-nav will force it to skip the height check and always reload, as it should.)