### PR TITLE
Don't use click-event callback to init tabs

### DIFF
--- a/apps/comics/templates/comics/js/reader.js
+++ b/apps/comics/templates/comics/js/reader.js
@@ -330,10 +330,10 @@ const COMICS = function () {
         if (activeTab === null || !["info-frame", "comments-frame", "quests-frame"].includes(activeTab)) {
             activeTab = "info-frame";
         }
-        activateTab(activeTab);
+        setTabActive(activeTab);
     }
 
-    function activateTab(target) {
+    function setTabActive(target) {
         localStorage.setItem("comics.activeTab", target);
 
         // Set tab styling
@@ -353,11 +353,15 @@ const COMICS = function () {
                 element.style.display = "none";
             }
         });
+    }
+
+    function activateTab(target) {
+        setTabActive(target);
 
         // Queue a refresh check if comments loaded invisibly (no height)
         if (target === 'comments-frame' && getCommentFrameHeight() <= 0) {
             window.setTimeout(() => {
-                refreshDiscourseComments(false);
+            refreshDiscourseComments(false);
             }, 0);
         }
     }


### PR DESCRIPTION
I realized the **real** problem was actually a simple one: `activateTab()`, which queues the size-based refresh, was being called on page init.

So, this splits `activateTab()` into two functions.

* `setTabActive()` now does the work of activating a tab.
* `activateTab()` now calls setTabActive(), then does the comments refresh check.

`initializeTabs()` will set up tab-click event listeners that call `activateTab()`, then call `setTabActive()` to initialize the active tab. `activateTab()` will never be called except in response to an actual tab click.

I'm leaving the `setTimeout()` in there on the theory that it's still the right way to handle the comments refresh — as long as it's not happening before the page is even fully loaded. (Which it no longer will be.)